### PR TITLE
Use "Accept: application/json" header instead of appending ".json" to sp...

### DIFF
--- a/soundcloud/client.py
+++ b/soundcloud/client.py
@@ -138,13 +138,9 @@ class Client(object):
     def _resolve_resource_name(self, name):
         """Convert a resource name (e.g. tracks) into a URI."""
         if name[:4] == 'http':  # already a url
-            if name[:4] != 'json' and name[-8:] not in ('download', 'stream'):
-                return '%s.json' % (name,)
             return name
         name = name.rstrip('/').lstrip('/')
-        if name[-13:] == 'contributions':
-            return '%s%s/%s' % (self.scheme, self.host, name)
-        return '%s%s/%s.json' % (self.scheme, self.host, name)
+        return '%s%s/%s' % (self.scheme, self.host, name)
 
     def _redirect_uri(self):
         """

--- a/soundcloud/request.py
+++ b/soundcloud/request.py
@@ -118,8 +118,13 @@ def make_request(method, url, params):
         raise TypeError('Unknown method: %s' % (method,))
 
     if method == 'get':
+        kwargs['headers']['Accept'] = 'application/json'
         qs = urllib.urlencode(data)
-        result = request_func('%s?%s' % (url, qs), **kwargs)
+        if '?' in url:
+            url_qs = '%s&%s' % (url, qs)
+        else:
+            url_qs = '%s?%s' % (url, qs)
+        result = request_func(url_qs, **kwargs)
     else:
         kwargs['data'] = data
         if files:

--- a/soundcloud/tests/test_client.py
+++ b/soundcloud/tests/test_client.py
@@ -31,9 +31,9 @@ def test_url_creation():
     """Test that resources are turned into urls properly."""
     client = soundcloud.Client(client_id='foo')
     url = client._resolve_resource_name('tracks')
-    eq_('https://api.soundcloud.com/tracks.json', url)
+    eq_('https://api.soundcloud.com/tracks', url)
     url = client._resolve_resource_name('/tracks/')
-    eq_('https://api.soundcloud.com/tracks.json', url)
+    eq_('https://api.soundcloud.com/tracks', url)
 
 
 def test_url_creation_options():
@@ -41,7 +41,7 @@ def test_url_creation_options():
     client = soundcloud.Client(client_id='foo', use_ssl=False)
     client.host = 'soundcloud.dev'
     url = client._resolve_resource_name('apps/132445')
-    eq_('http://soundcloud.dev/apps/132445.json', url)
+    eq_('http://soundcloud.dev/apps/132445', url)
 
 
 def test_method_dispatching():
@@ -73,7 +73,8 @@ def test_disabling_ssl_verification(fake_get):
             'client_id': 'foo'
         }))
     headers = {
-        'User-Agent': soundcloud.USER_AGENT
+        'User-Agent': soundcloud.USER_AGENT,
+        'Accept': 'application/json'
     }
     (fake_get.expects_call()
              .with_args(expected_url,
@@ -105,7 +106,8 @@ def test_method_dispatching_get_request_readonly(fake_get):
             'client_id': 'foo'
         }))
     headers = {
-        'User-Agent': soundcloud.USER_AGENT
+        'User-Agent': soundcloud.USER_AGENT,
+        'Accept': 'application/json'
     }
     (fake_get.expects_call()
              .with_args(expected_url, headers=headers, allow_redirects=True)
@@ -151,7 +153,8 @@ def test_proxy_servers(fake_request):
         })
     )
     headers = {
-        'User-Agent': soundcloud.USER_AGENT
+        'User-Agent': soundcloud.USER_AGENT,
+        'Accept': 'application/json'
     }
     (fake_request.expects_call()
                  .with_args(expected_url,


### PR DESCRIPTION
Use "Accept: application/json" header instead of appending ".json" to specify that JSON is requested. Fixes almost-certainly-buggy code in client.py method _resolve_resource_name().

Fix bug which would not allow a full url with a query string to be used successfully with Client.get().
