### PR TITLE
assume encoding utf-8 when unset

### DIFF
--- a/soundcloud/resource.py
+++ b/soundcloud/resource.py
@@ -60,6 +60,8 @@ def wrapped_resource(response):
         result = ResourceList(content)
     else:
         result = Resource(content)
+        if hasattr(result, 'collection'):
+            result.collection = ResourceList(result.collection)
     result.raw_data = response_content
 
     for attr in ('encoding', 'url', 'status_code', 'reason'):

--- a/soundcloud/resource.py
+++ b/soundcloud/resource.py
@@ -48,8 +48,8 @@ def wrapped_resource(response):
     Lists will be returned as a ```ResourceList``` instance,
     dicts will be returned as a ```Resource``` instance.
     """
-    # decode response text
-    response_content = response.content.decode(response.encoding)
+    # decode response text, assuming utf-8 if unset
+    response_content = response.content.decode(response.encoding or 'utf-8')
 
     try:
         content = json.loads(response_content)

--- a/soundcloud/resource.py
+++ b/soundcloud/resource.py
@@ -13,6 +13,8 @@ class Resource(object):
     """
     def __init__(self, obj):
         self.obj = obj
+        if hasattr(self, 'origin'):
+            self.origin = Resource(self.origin)
 
     def __getstate__(self):
         return self.obj.items()


### PR DESCRIPTION
Been struggling to get ```client.get('/me/activities')``` working, since the encoding isn't "properly" determined to ```utf-8``` by requests. Assuming ```utf-8``` fixes this for me, and I think adresses #35 as well. I don't think it's an unreasonable assuption.

Further investigation shows that the response charset isn't set by soundcloud:
```bash
 ~ > curl -I -X GET https://api.soundcloud.com/me/activities/tracks.json\?oauth_token\=VALID_TOKEN\&limit\=3
HTTP/1.1 200 OK
Access-Control-Allow-Headers: Accept, Authorization, Content-Type, Origin
Access-Control-Allow-Methods: GET, PUT, POST, DELETE
Access-Control-Allow-Origin: *
Access-Control-Expose-Headers: Date
Cache-Control: private, max-age=0
Content-Type: application/json
Date: Sat, 03 Jan 2015 00:14:23 GMT
Server: am/2
Set-Cookie: _session_auth_key="..."
Set-Cookie: _session_auth_key="..."
Content-Length: 8466
```

You'd expect a ```charset=utf-8``` in ```Content-type```, as you get for most every other request to the api.

Update: Meant for only the first commit below to be included in the PR. Two other commits relate to #53. Should've put them in a separate branch, don't know if you can selectively merge only first patch?