### PR TITLE
Allow never version of fudge (1.0.3 and up)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         '': ['README.rst']
     },
     install_requires=[
-        'fudge==1.0.3',
+        'fudge>=1.0.3',
         'requests>=0.14.0',
         'simplejson>=2.0',
     ],


### PR DESCRIPTION
`fudge 1.1.0` is out:
[pypi: fudge 1.1.0](https://pypi.python.org/pypi/fudge/1.1.0)

 `soundcloud-python` builds fine with the new version, so I would propose lifting the requirement for v1.0.3. What do you think?