### PR TITLE
Fix imports

### DIFF
--- a/soundcloud/__init__.py
+++ b/soundcloud/__init__.py
@@ -3,6 +3,4 @@
 __version__ = '0.5.0'
 __all__ = ['Client']
 
-USER_AGENT = 'SoundCloud Python API Wrapper %s' % __version__
-
 from client import Client

--- a/soundcloud/__init__.py
+++ b/soundcloud/__init__.py
@@ -5,4 +5,4 @@ __all__ = ['Client']
 
 USER_AGENT = 'SoundCloud Python API Wrapper %s' % __version__
 
-from soundcloud.client import Client
+from client import Client

--- a/soundcloud/client.py
+++ b/soundcloud/client.py
@@ -4,8 +4,8 @@ try:
 except ImportError:
     from urllib.parse import urlencode
 
-from soundcloud.resource import wrapped_resource
-from soundcloud.request import make_request
+from resource import wrapped_resource
+from request import make_request
 
 
 class Client(object):

--- a/soundcloud/request.py
+++ b/soundcloud/request.py
@@ -6,7 +6,8 @@ except ImportError:
 import requests
 import six
 
-from soundcloud import USER_AGENT
+__version__ = '0.5.0'
+USER_AGENT = 'SoundCloud Python API Wrapper %s' % __version__
 
 from . import hashconversions
 

--- a/soundcloud/request.py
+++ b/soundcloud/request.py
@@ -6,7 +6,7 @@ except ImportError:
 import requests
 import six
 
-import soundcloud
+from soundcloud import USER_AGENT
 
 from . import hashconversions
 
@@ -104,7 +104,7 @@ def make_request(method, url, params):
     kwargs = {
         'allow_redirects': allow_redirects,
         'headers': {
-            'User-Agent': soundcloud.USER_AGENT
+            'User-Agent': USER_AGENT
         }
     }
     # options, not params


### PR DESCRIPTION
### Summary
I work at Zefr, Inc. and was attempting to use the soundcloud-python library to connect to SoundCloud. Whenever I attempted to use the library I would get this error:
```
Traceback (most recent call last):
  File "soundcloud_test.py", line 1, in <module>
    import soundcloud
  File "/usr/local/lib/python2.7/dist-packages/soundcloud/__init__.py", line 8, in <module>
    from soundcloud.client import Client
ImportError: No module named client
```
This PR removes the 'soundcloud' module name from the imports and moves USER_AGENT into request.py where it is used.