### PR TITLE
Added exception class attribute to Client

### DIFF
--- a/soundcloud/client.py
+++ b/soundcloud/client.py
@@ -4,6 +4,8 @@ try:
 except ImportError:
     from urllib.parse import urlencode
 
+from requests.exceptions import HTTPError
+
 from soundcloud.resource import wrapped_resource
 from soundcloud.request import make_request
 
@@ -13,6 +15,7 @@ class Client(object):
 
     use_ssl = True
     host = 'api.soundcloud.com'
+    http_error = HTTPError
 
     def __init__(self, **kwargs):
         """Create a client instance with the provided options. Options should


### PR DESCRIPTION
I added a class attribute to Client that contains a reference to the "requests" library's HTTPError exception. This allows granular exception handling of API requests without introducing a dependency on the "requests" library in consuming code.

For example, when attempting to resolve a user's soundcloud.com permalink URL to an API resource ID, submitting a nonexistent permalink to the API will throw a resource.exceptions.HTTPError. One cannot catch this exception without reducing granularity (unspecified exception class in try-except statement) or importing the "requests" package into the calling code and using the contents of its exceptions module in the try-except statement.

These few added lines eliminate the leaked abstraction. I would prefer that my code not have to know how soundcloud-python makes its HTTP requests.