### PR TITLE
fix TypeError when iterating through activities

### DIFF
--- a/soundcloud/resource.py
+++ b/soundcloud/resource.py
@@ -43,7 +43,7 @@ class Resource(object):
 class ResourceList(UserList):
     """Object wrapper for lists of resources."""
     def __init__(self, resources=[]):
-        data = [Resource(resource) for resource in resources]
+        data = [Resource(resource) for resource in resources if resource['origin'] is not None]
         super(ResourceList, self).__init__(data)
 
 


### PR DESCRIPTION
```python
  File "/usr/lib/python3.5/site-packages/soundcloud/client.py", line 133, in _request
    return wrapped_resource(make_request(method, url, kwargs))
  File "/usr/lib/python3.5/site-packages/soundcloud/resource.py", line 69, in wrapped_resource
    result.collection = ResourceList(result.collection)
  File "/usr/lib/python3.5/site-packages/soundcloud/resource.py", line 46, in __init__
    data = [Resource(resource) for resource in resources]
  File "/usr/lib/python3.5/site-packages/soundcloud/resource.py", line 46, in <listcomp>
    data = [Resource(resource) for resource in resources]
  File "/usr/lib/python3.5/site-packages/soundcloud/resource.py", line 20, in __init__
    self.origin = Resource(self.origin)
  File "/usr/lib/python3.5/site-packages/soundcloud/resource.py", line 19, in __init__
    if hasattr(self, 'origin'):
  File "/usr/lib/python3.5/site-packages/soundcloud/resource.py", line 32, in __getattr__
    if name in self.obj:
TypeError: argument of type 'NoneType' is not iterable
```
when going through my stream, it consistently crashes upon trying to get the next href when it encounters something I suspect is a deleted repost. It has an empty origin, so attempting to create a Resource of it it generates a TypeError. Skipping resources with empty origins in generating the data variable solves the problem. When viewing on the website I can find the previous and next track, but there's nothing inbetween them.

This is what the resource looks like that crashes Resource()
```python
(Pdb) resource
{'tags': None, 'origin': None, 'type': 'track-repost', 'created_at': '2016/09/19 17:10:57 +0000'}
```

it's a minimal change, so I don't think there'll be any fallout from it.